### PR TITLE
Update forge version to 1.12.2-14.23.5.2847 (latest tagged)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,17 +10,19 @@ buildscript {
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
+apply plugin: 'maven-publish'
 
 
 version = "2.0"
 group = "com.github.terminatornl.tickcentral" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "TickCentral"
 
-if (project.gradle.startParameter.taskNames.contains("jar")) {
+def taskNames = project.gradle.startParameter.taskNames
+if (taskNames.contains("jar")) {
     version = "$version-dev"
-}else if (project.gradle.startParameter.taskNames.contains("sign")) {
+}else if (taskNames.contains("sign")) {
     //Version not affected
-}else if (!project.gradle.startParameter.taskNames.contains("install")) {
+}else if (!taskNames.find {it.toLowerCase().startsWith("publish")} && !taskNames.contains("install")) { // matches "publish", "publishToMavenLocal" and "install" tasks
     version = "$version-testing"
 }
 
@@ -135,3 +137,14 @@ task signJar(type: SignJar, dependsOn: reobfJar) {
 }
 install.dependsOn build
 build.dependsOn signJar
+
+publishing { // for the publishToMavenLocal task
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ compileJava {
 
 minecraft {
     ///home/predator/.gradle/caches/minecraft/de/oceanlabs/mcp/mcp
-    version = "1.12.2-14.23.5.2838"
+    version = "1.12.2-14.23.5.2847"
     runDir = "run"
 
     replaceIn "TickCentral.java"

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ processResources {
     }
 }
 
-task install << {
+task installToObfServer << {
     delete fileTree('run_server_obf/mods') {
         include "$archivesBaseName*"
     }


### PR DESCRIPTION
Versions newer than 1.12.2-14.23.5.2847 do exist however are not tagged as "latest" on minecraft forge website.

I also added a publishToMavenLocal task to allow easier use as a library, see TerminatorNL/LagGoggles#105