### PR TITLE
Ignore invalid Jars from the mods folder.

### DIFF
--- a/src/main/java/com/github/terminatornl/tickcentral/loading/Loader.java
+++ b/src/main/java/com/github/terminatornl/tickcentral/loading/Loader.java
@@ -122,11 +122,15 @@ public class Loader {
 			}
 
 			for (File file : potentialMods) {
-				JarFile jar = new JarFile(file);
-				ZipEntry transformerEntry = jar.getEntry(TickCentral.NAME + "-loadable.txt");
-				if(transformerEntry != null){
-					BufferedReader reader = new BufferedReader(new InputStreamReader(jar.getInputStream(transformerEntry)));
-					parseLoadables(reader, file);
+				try {
+					JarFile jar = new JarFile(file);
+					ZipEntry transformerEntry = jar.getEntry(TickCentral.NAME + "-loadable.txt");
+					if (transformerEntry != null) {
+						BufferedReader reader = new BufferedReader(new InputStreamReader(jar.getInputStream(transformerEntry)));
+						parseLoadables(reader, file);
+					}
+				} catch (Throwable e) {
+					TickCentral.LOGGER.warn("Failed to load {}-loadable.txt from File '{}', Ignoring..",TickCentral.NAME, file, e);
 				}
 			}
 		}catch (Throwable e){


### PR DESCRIPTION
Pretty simple, don't explode when there's an invalid jar.
Example: https://gist.github.com/covers1624/8da434c84d11bc6162d2db4dbbfc84b4